### PR TITLE
fix: model selector tooltip renders raw HTML tags instead of text

### DIFF
--- a/src/__test__/components/form-items/select.spec.ts
+++ b/src/__test__/components/form-items/select.spec.ts
@@ -6,6 +6,21 @@
 import { Select, SelectInternal, SelectProps } from '../../../components/form-items/select';
 import { MynahIcons } from '../../../components/icon';
 import { DomBuilder } from '../../../helper/dom';
+import { configureMarked } from '../../../helper/marked';
+
+// Mock the overlay component so we can capture the tooltip content that gets rendered,
+// without depending on the real Overlay's positioning logic.
+jest.mock('../../../components/overlay', () => ({
+  Overlay: jest.fn().mockImplementation(() => ({
+    close: jest.fn()
+  })),
+  OverlayHorizontalDirection: {
+    START_TO_RIGHT: 'start-to-right'
+  },
+  OverlayVerticalDirection: {
+    TO_TOP: 'to-top'
+  }
+}));
 
 describe('Select Component', () => {
   let select: SelectInternal;
@@ -359,6 +374,89 @@ describe('Select Component', () => {
       selectElement.dispatchEvent(new Event('change'));
 
       expect(select.getValue()).toBe('option2');
+    });
+  });
+
+  describe('Tooltip content', () => {
+    // Options that carry a description mirror the model-selector use case, where the
+    // hover tooltip shows the selected model's label and description.
+    const optionsWithDescription = [
+      { value: 'model1', label: 'Claude Sonnet 4', description: 'Hybrid reasoning and coding for regular use' },
+      { value: 'model2', label: 'Claude Haiku', description: 'Fast responses for lightweight tasks' }
+    ];
+
+    beforeEach(() => {
+      // The tooltip is rendered through the markdown parser, which (in production) escapes
+      // raw HTML. Configure marked here so the test reflects real rendering behavior.
+      configureMarked();
+      jest.useFakeTimers();
+      const { Overlay } = jest.requireMock('../../../components/overlay');
+      (Overlay as jest.Mock).mockClear();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    const openTooltip = (): HTMLElement => {
+      document.body.appendChild(select.render);
+      const container = document.body.querySelector('.mynah-form-input-container') as HTMLElement;
+      container.dispatchEvent(new MouseEvent('mouseenter'));
+      jest.advanceTimersByTime(350);
+
+      const { Overlay } = jest.requireMock('../../../components/overlay');
+      expect(Overlay).toHaveBeenCalledTimes(1);
+      const overlayProps = (Overlay as jest.Mock).mock.calls[0][0];
+      // The overlay renders a Card whose body is the parsed tooltip content.
+      return overlayProps.children[0] as HTMLElement;
+    };
+
+    it('should render the tooltip as markdown, not raw HTML tags', () => {
+      select = new SelectInternal({
+        options: optionsWithDescription,
+        value: 'model1'
+      });
+
+      const tooltipContent = openTooltip();
+
+      // The label must render as a real bold element, not literal "<strong>" text.
+      const strongElement = tooltipContent.querySelector('strong');
+      expect(strongElement).not.toBeNull();
+      expect(strongElement?.textContent).toBe('Claude Sonnet 4');
+
+      // Regression guard: the raw HTML tags must never leak into the visible text.
+      expect(tooltipContent.textContent).not.toContain('<strong>');
+      expect(tooltipContent.textContent).not.toContain('<br>');
+
+      // Both label and description should be present in the rendered tooltip.
+      expect(tooltipContent.textContent).toContain('Claude Sonnet 4');
+      expect(tooltipContent.textContent).toContain('Hybrid reasoning and coding for regular use');
+    });
+
+    it('should reflect the currently selected option in the tooltip', () => {
+      select = new SelectInternal({
+        options: optionsWithDescription,
+        value: 'model1'
+      });
+      select.setValue('model2');
+
+      const tooltipContent = openTooltip();
+
+      expect(tooltipContent.querySelector('strong')?.textContent).toBe('Claude Haiku');
+      expect(tooltipContent.textContent).toContain('Fast responses for lightweight tasks');
+      expect(tooltipContent.textContent).not.toContain('<strong>');
+    });
+
+    it('should fall back to the base tooltip when the option has no description', () => {
+      select = new SelectInternal({
+        options: testOptions,
+        value: 'option1',
+        tooltip: 'Base tooltip text'
+      });
+
+      const tooltipContent = openTooltip();
+
+      expect(tooltipContent.textContent).toContain('Base tooltip text');
     });
   });
 });

--- a/src/components/form-items/select.ts
+++ b/src/components/form-items/select.ts
@@ -149,9 +149,11 @@ export class SelectInternal {
     const currentValue = this.selectElement.value;
     const selectedOption = this.props.options?.find(option => option.value === currentValue);
 
-    // If there's a selected option, show label and description; otherwise use the base tooltip
+    // If there's a selected option, show label and description; otherwise use the base tooltip.
+    // The tooltip is rendered through the markdown parser (via CardBody), which escapes raw HTML,
+    // so use markdown syntax (bold + line break) instead of HTML tags to avoid showing literal markup.
     if (selectedOption?.description != null) {
-      return `<strong>${selectedOption.label}</strong><br>${selectedOption.description}`;
+      return `**${selectedOption.label}**\n${selectedOption.description}`;
     }
     return this.props.tooltip ?? '';
   };

--- a/ui-tests/__test__/flows/quick-action-commands-header.ts
+++ b/ui-tests/__test__/flows/quick-action-commands-header.ts
@@ -140,7 +140,7 @@ export const verifyQuickActionCommandsHeaderStatusVariations = async (page: Page
     const hasStatus = await headerElement.evaluate((el, className) =>
       el.classList.contains(className), statusClass
     );
-    if (hasStatus) {
+    if (hasStatus === true) {
       foundStatusClass = true;
       console.log(`Found status class: ${statusClass}`);
       break;

--- a/ui-tests/__test__/flows/quick-action-commands-header.ts
+++ b/ui-tests/__test__/flows/quick-action-commands-header.ts
@@ -137,10 +137,10 @@ export const verifyQuickActionCommandsHeaderStatusVariations = async (page: Page
   let foundStatusClass = false;
 
   for (const statusClass of statusClasses) {
-    const hasStatus = await headerElement.evaluate((el, className) =>
+    const hasStatus = Boolean(await headerElement.evaluate((el, className) =>
       el.classList.contains(className), statusClass
-    );
-    if (hasStatus === true) {
+    ));
+    if (hasStatus) {
       foundStatusClass = true;
       console.log(`Found status class: ${statusClass}`);
       break;


### PR DESCRIPTION
## Summary

The model selector's hover tooltip displayed raw HTML tags (e.g. `<strong>` and `<br>`) as literal text instead of a formatted label and description. This makes the tooltip look broken to users. This PR fixes the tooltip to render correctly and adds unit tests to guard against regression.

## Problem

When hovering over a `select` form item that has options with a `description` (such as the model selector in chat), the tooltip showed something like:

```
<strong>Claude Sonnet 4</strong><br>Hybrid reasoning and coding for regular use
```

instead of a bold label followed by its description.

## Screenshots

### Before

<img width="485" height="188" alt="Screenshot 2026-09-15 at 12 30 20 PM" src="https://github.com/user-attachments/assets/12248acc-ed2d-43dc-86ff-fc39f268927a" />
<img width="469" height="168" alt="Screenshot 2026-09-15 at 12 30 13 PM" src="https://github.com/user-attachments/assets/b3055696-2b94-4811-a2c0-31e99afe4b5f" />

### After
<img width="464" height="177" alt="Screenshot 2026-09-15 at 12 15 45 PM" src="https://github.com/user-attachments/assets/9f3fee00-c8d3-4101-8ac0-44f8acb8b3c9" />
<img width="441" height="138" alt="Screenshot 2026-09-15 at 12 15 38 PM" src="https://github.com/user-attachments/assets/9ee6403d-f5a3-427f-871f-0cc55b0b1f2f" />


## Root cause

`SelectInternal.getCurrentTooltip()` in `src/components/form-items/select.ts` built the tooltip content using raw HTML tags:

```ts
return `<strong>${selectedOption.label}</strong><br>${selectedOption.description}`;
```

That string is passed to `showTooltip()`, which renders it through a `CardBody`. `CardBody` renders its `body` via the markdown parser (`parseMarkdown`), and the parser's HTML renderer is configured to escape raw HTML:

```ts
// src/helper/marked.ts -> configureMarked()
html: ({ text }) => escapeHTML(text),
```

As a result, the raw `<strong>` / `<br>` tags were escaped and shown to the user verbatim.

## Fix

Use markdown syntax instead of raw HTML so the content renders correctly through the same parser:

```ts
return `**${selectedOption.label}**\n${selectedOption.description}`;
```

`CardBody` already invokes the parser with line breaks enabled (`includeLineBreaks: true`), so the newline becomes a line break and `**…**` renders as bold — producing the intended "bold label + description" tooltip without any raw HTML.

## Testing

- Added unit tests in `src/__test__/components/form-items/select.spec.ts` covering the tooltip content path:
  - the tooltip renders as markdown (a real `<strong>` element) and never leaks literal `<strong>` / `<br>` text;
  - the tooltip reflects the currently selected option;
  - it falls back to the base `tooltip` when the selected option has no description.
- The new tests were confirmed to fail against the previous (raw-HTML) implementation and pass with this change.
- Full unit test suite passes (`npx jest`): 72 suites / 845 tests.
- `eslint` and `prettier --check` pass; production build (`npm run build`) succeeds.

## Additional change

- `ui-tests/__test__/flows/quick-action-commands-header.ts`: replaced an implicit truthiness check on an `any`-typed value with an explicit boolean comparison to satisfy `@typescript-eslint/strict-boolean-expressions`. This was a pre-existing lint error unrelated to the tooltip fix; correcting it keeps the lint gate green.

## Notes

- Change is limited to tooltip content generation; no public API changes.
